### PR TITLE
remove condition which is always true, remove loop to prevent jumping

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -191,8 +191,6 @@ export default class RememberCursorPosition extends Plugin {
 			this.loadingFile = false;
 		}
 
-	}
-
 	async readDb(): Promise<{ [file_path: string]: EphemeralState; }> {
 		let db: { [file_path: string]: EphemeralState; } = {}
 

--- a/main.ts
+++ b/main.ts
@@ -179,16 +179,10 @@ export default class RememberCursorPosition extends Plugin {
 						await this.delay(10)
 					}
 
-					//if note opened by link like [link](note.md#header), do not scroll it
+					// TODO: if note opened by link like [link](note.md#header), do not scroll it
 					
-					// CHANGE this expression for compatability with the new PROPERTIES view after Obsidian Version 1.4
-					if (scroll === 0 || true) {
-						//force update scroll while note is loading
-						//todo: find better solution to wait for file loaded
-						for (let i = 0; i < 20; i++) {
-							this.setEphemeralState(st);
-							await this.delay(10)
-						}
+					await this.delay(10)
+					this.setEphemeralState(st);
 					}
 				}
 				this.lastEphemeralState = st;


### PR DESCRIPTION
Reverts https://github.com/dy-sh/obsidian-remember-cursor-position/pull/44.

Should fix  #47 and  #50.

After the update of Obsidian which introduces properties, the files are not opened on top of the document anymore. Figuring out when the document is opened at the top has become more tricky. Therefore I removed the check for the scroll position and added a delay before restoring the previous position. I did some quick testing only, but it seems like this is working fine to restore the scroll position without jumping back and forth. 