### PR TITLE
fix: Don't scroll when a link scrolls and highlights text

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -185,18 +185,16 @@ export default class RememberCursorPosition extends Plugin {
 				if (st) {
 					//waiting for load note
 					await this.delay(this.settings.delayAfterFileOpening)
-					let scroll: number;
-					for (let i = 0; i < 20; i++) {
-						scroll = this.app.workspace.getActiveViewOfType(MarkdownView)?.currentMode?.getScroll();
-						if (scroll !== null)
-							break;
-						await this.delay(10)
-					}
 
-					// TODO: if note opened by link like [link](note.md#header), do not scroll it
-					
-					await this.delay(10)
-					this.setEphemeralState(st);
+					// Don't scroll when a link scrolls and highlights text
+					// i.e. if file is open by links like [link](note.md#header) and wikilinks
+					// See #10, #32, #46, #51
+					let containsFlashingSpan = this.app.workspace.containerEl.querySelector('span.is-flashing');
+
+					if (!containsFlashingSpan) {
+						await this.delay(10)
+						this.setEphemeralState(st);
+					}
 				}
 			} 
 			this.lastEphemeralState = st;


### PR DESCRIPTION
Should fix, but requires confirmation: #10, #32, #46 and #51

When opening a file from wikilink/link with header and link with block id (i.e. [[note#header]], [[note#^blockId]]),
obsidian highlights and scrolls to the corresponding header and text.
The issue is that the plugin restores the saved scroll, despite the highlighted text.

A fix was implemented in 7bae48c by checking if obsidian has scrolled or not (`scroll === 0`).
But, this doesn't work for files with properties: getScroll returns the cursor position, which is at the end of the properties when opening a file. For files with properties, scroll is not 0, so the plugin doesn't restore the state.
`scroll === 0` was removed in commits #44 and #52, waiting for another solution.

This new solution checks for any dom element in a span.is-flashing.
This dom is created by obsidian when a specific text is highlighted (and scrolled) after clicking a link.

Since the check for `scroll === 0` was removed, the for loop shouldn't be necessary (introduced in 7bae48c).
delayAfterFileOpening too, but it might be worth keeping(?)