### PR TITLE
chore: upgrade @rollup/plugin-typescript to ^8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@rollup/plugin-typescript": "^6.0.0",
+    "@rollup/plugin-typescript": "^8.5.0",
     "@types/node": "^14.14.2",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1",


### PR DESCRIPTION
v6.x uses a load/resolveId approach that silently fails on Windows due to path separator mismatches, causing Rollup to parse main.ts as plain JavaScript and error on TypeScript syntax. v8 switched to a transform hook which resolves correctly cross-platform.