### PR TITLE
Fix cursor position not saving on first visit and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,49 @@
-# Remember cursor position
+# Remember Cursor Position
 
-This plugin for [Obsidian](https://obsidian.md/) remembers the cursor position and scroll for each note. This is very convenient when you switch between notes, go from link to link, go back, you do not need to scroll to the place where you were the last time.
+An [Obsidian](https://obsidian.md/) plugin that remembers the cursor position, scroll position, and text selection for each note.
 
-The cursor position, scrolling and text selection  for all notes are stored in a file (the path can be set in the settings), so everything is restored even if you close Obsidian and open it again.
+## Features
 
-It works in edit and preview mode.
+- **Cursor position** — returns to the exact line and column you were editing
+- **Scroll position** — restores where you were scrolled to in the document
+- **Text selection** — preserves any selected text when reopening a note
+- **Edit & Preview modes** — works in both editing and reading views
+- **Persistent storage** — positions are saved to a JSON file (configurable path) and survive app restarts
+- **Smart restoration** — avoids unwanted scrolling when opening links that target a specific section (`#header` links)
+- **Configurable defaults** — choose what happens when no saved position exists: go to beginning, end, before footnotes, or do nothing
+- **Pruning** — optionally remove entries for deleted files, old entries by age, or cap the total number of stored positions
 
+## How it works
 
+Each time you move the cursor or scroll in a note, the plugin records that state. When you come back to the same note (even after closing and reopening Obsidian), it restores your exact position and selection. This makes navigating between notes seamless — no more manually scrolling to find your place.
+
+## Installation
+
+### From Obsidian Community Plugins
+
+1. Open **Settings** → **Community plugins**
+2. Disable **Restricted mode** (if enabled)
+3. Click **Browse** and search for "Remember Cursor Position"
+4. Install and enable the plugin
+
+### Manual installation
+
+1. Download the latest release from the [releases page](https://github.com/LorenBll/obsidian-remember-cursor-position/releases)
+2. Extract the files into your vault's `.obsidian/plugins/remember-cursor-position/` directory
+3. Enable the plugin in **Settings** → **Community plugins**
+
+## Settings
+
+| Setting | Description |
+|---------|-------------|
+| Default cursor position | What to do when no saved position exists for a file (Beginning / End / Before footnotes / Default — do nothing) |
+| Data file name | Path to the JSON file where positions are stored |
+| Delay after opening a new note | Prevents unwanted scrolling when opening links with section anchors |
+| Delay between saving | How often the position database is written to disk |
+| Remove entries for deleted files | Prune positions for files that no longer exist in the vault |
+| Remove entries older than | Automatically discard positions not updated within the selected period |
+| Maximum number of entries to keep | Limit the database size by keeping only the most recently visited files |
+
+## Support
+
+If you find a bug or have a feature request, please [open an issue](https://github.com/LorenBll/obsidian-remember-cursor-position/issues).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each time you move the cursor or scroll in a note, the plugin records that state
 
 ### Manual installation
 
-1. Download the latest release from the [releases page](https://github.com/LorenBll/obsidian-remember-cursor-position/releases)
+1. Download the latest release from the [releases page](https://github.com/dy-sh/obsidian-remember-cursor-position/releases)
 2. Extract the files into your vault's `.obsidian/plugins/remember-cursor-position/` directory
 3. Enable the plugin in **Settings** → **Community plugins**
 
@@ -46,4 +46,4 @@ Each time you move the cursor or scroll in a note, the plugin records that state
 
 ## Support
 
-If you find a bug or have a feature request, please [open an issue](https://github.com/LorenBll/obsidian-remember-cursor-position/issues).
+If you find a bug or have a feature request, please [open an issue](https://github.com/dy-sh/obsidian-remember-cursor-position/issues).

--- a/main.ts
+++ b/main.ts
@@ -122,10 +122,12 @@ export default class RememberCursorPosition extends Plugin {
 
 		let st = this.getEphemeralState();
 
+		let hadPriorState = this.lastEphemeralState && Object.keys(this.lastEphemeralState).length > 0;
+
 		if (!this.lastEphemeralState)
 			this.lastEphemeralState = st;
 
-		if (!isNaN(st.scroll) && !this.isEphemeralStatesEquals(st, this.lastEphemeralState)) {
+		if (!isNaN(st.scroll) && (!hadPriorState || !this.isEphemeralStatesEquals(st, this.lastEphemeralState))) {
 			this.saveEphemeralState(st);
 			this.lastEphemeralState = st;
 		}
@@ -568,14 +570,14 @@ class SettingTab extends PluginSettingTab {
 			.addSetting((setting) =>
 				setting
 					.setName('Maximum number of entries to keep')
-					.setDesc('On startup, if the number of saved positions exceeds this limit, the oldest entries are removed. Most-recently visited files are kept.')
+					.setDesc('On startup, if the number of saved positions exceeds this limit, the oldest entries are removed. Most-recently visited files are kept. "None" means no maximum limit.')
 					.addDropdown((drop) =>
 						drop
 							.addOption('50', '50')
 							.addOption('100', '100')
 							.addOption('250', '250')
 							.addOption('500', '500')
-							.addOption('0', 'Never')
+							.addOption('0', 'None')
 							.setValue(String(this.plugin.settings.maxCount))
 							.onChange(async (value) => {
 								this.plugin.settings.maxCount = Number(value);


### PR DESCRIPTION
## Fix: cursor position not saved on first visit
Fixed a bug in checkEphemeralStateChanged where the cursor position was never saved for files that had no previously stored state. This happened because lastEphemeralState was compared against itself after being assigned the current state. Now the plugin correctly tracks whether a prior state existed and saves accordingly.

## UI: rename "Never" to "None" in max-entries dropdown
Changed the "Never" option label to "None" in the "Maximum number of entries to keep" dropdown and updated the description to clarify that None means no limit is applied.

## Better README
Rewrote the README with a comprehensive project description, feature list, how-it-works explanation, installation guide (both community plugins and manual), a settings reference table, and a support link.